### PR TITLE
Remove basic auth for accessing staging API

### DIFF
--- a/nginx-staging/nginx.conf
+++ b/nginx-staging/nginx.conf
@@ -23,10 +23,16 @@ http {
       proxy_set_header Host $http_host;
       proxy_redirect off;
     }
+    # Remove basic auth for api access
+    location /api/v1/ {
+      proxy_pass http://project-application:8085;
+
+      proxy_set_header Host $http_host;
+      proxy_redirect off;
+    }
     
     location /static/ {
       alias /code/ProjectApplication/staticfiles/;
     }
   }
 }
-


### PR DESCRIPTION
Due to restriction with REST API we can't manage 2 authentications in same request. So I propose to remove basic auth to access /api/v1/ path.